### PR TITLE
Add pprint for import in chapter 9

### DIFF
--- a/ja/chap09.md
+++ b/ja/chap09.md
@@ -11,6 +11,7 @@ layout: default
 次のコードを書きなさい。
 
 ```python
+import pprint
 import numpy as np
 from fractions import Fraction
 


### PR DESCRIPTION
In the preparation code, we should import `pprint` because we use it later.