### PR TITLE
Add pprint for import in chapter 10

### DIFF
--- a/ja/chap10.md
+++ b/ja/chap10.md
@@ -11,6 +11,7 @@ layout: default
 次のコードを書きなさい。
 
 ```python
+import pprint
 import numpy as np
 
 Du = np.array([


### PR DESCRIPTION
In the preparation code, we should import `pprint` because we use it later.